### PR TITLE
Fix privacy issues when using 3D Dice

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -18,7 +18,8 @@ class Roll3D extends Roll {
     async roll() {
         let result = super.roll();
         if (game.dice3d) {
-            game.dice3d.showForRoll(this).then(() => {return result;});
+            let wd = getWhisperData();
+            game.dice3d.showForRoll(this, wd.whisper, wd.blind || false).then(() => {return result;});
         }
         return result;
     }


### PR DESCRIPTION
Ensures that the expected privacy arguments are passed through to the 3D dice animation to ensure that users don't see dice rolls they aren't supposed to.

Addresses #32.