### PR TITLE
Avoid NPE when rolling weapon attacks

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -914,7 +914,7 @@ export class CustomItemRoll {
 			if (itemData.properties.fin && (itemData.ability === "str" || itemData.ability === "dex" || itemData.ability === "")) {
 				if (actorData.abilities.str.mod >= actorData.abilities.dex.mod) { abl = "str"; }
 				else { abl = "dex"; }
-			} else { abl = itemData.ability; }
+			} else { abl = itemData.ability || (itemData.actionType === "mwak" ? "str" : itemData.actionType === "rwak" ? "dex" : "") }
 		} else {
 			abl = itemData.ability || "";
 		}


### PR DESCRIPTION
- Default to strength for melee weapon attacks
- Default to dexterity for ranged weapon attacks
- Fall back on empty string to avoid crash where `itemData.ability` is `null` (e.g. "Defender Longsword" from the SRD Items compendium