### PR TITLE
added support for metaKey to be treated as ctrlKey

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -563,7 +563,7 @@ export function changeRollsToDual (actor, html, data, params) {
 			event.preventDefault();
 			let ability = getAbility(event.currentTarget),
 				abl = actor.data.data.abilities[ability];
-			if ( event.ctrlKey ) {
+			if ( event.ctrlKey || event.metaKey ) {
 				CustomRoll.fullRollAttribute(actor, ability, "check");
 			} else if ( event.shiftKey ) {
 				CustomRoll.fullRollAttribute(actor, ability, "save");

--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -104,7 +104,7 @@ export class CustomRoll {
 	static eventToAdvantage(ev) {
 		let output = {adv:0, disadv:0};
 		if (ev.shiftKey) { output.adv = 1; }
-		if (ev.ctrlKey) { output.disadv = 1; }
+		if (ev.ctrlKey || ev.metaKey) { output.disadv = 1; }
 		return output;
 	}
 	
@@ -387,7 +387,7 @@ export class CustomItemRoll {
 		if (eventToCheck.shiftKey) {
 			this.params.adv = 1;
 		}
-		if (eventToCheck.ctrlKey) {
+		if (eventToCheck.ctrlKey || eventToCheck.metaKey) {
 			this.params.disadv = 1;
 		}
 	}


### PR DESCRIPTION
This is MacOS specific issue.

Cmd button usually works like ctrl button for most cases in MacOS, however it does not register as `ctrlClick` in `mouseEvent`. On MacOS cmd behavior is *almost* identical to ctrl. Can't use ctrl+click because this is treated by MacOS as right mouse click.

Looking at https://stackoverflow.com/a/3922353/2660065 I realized that we could just use `metaKey` the same way `ctrlKey` is used. So to allow disadvantage rolls. It should not interfere with Windows or Linux users.