### PR TITLE
should use keyboard.isCtrl(event) instead of event.ctrlKey

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -563,7 +563,7 @@ export function changeRollsToDual (actor, html, data, params) {
 			event.preventDefault();
 			let ability = getAbility(event.currentTarget),
 				abl = actor.data.data.abilities[ability];
-			if ( event.ctrlKey ) {
+			if ( keyboard.isCtrl(event) ) {
 				CustomRoll.fullRollAttribute(actor, ability, "check");
 			} else if ( event.shiftKey ) {
 				CustomRoll.fullRollAttribute(actor, ability, "save");

--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -104,7 +104,7 @@ export class CustomRoll {
 	static eventToAdvantage(ev) {
 		let output = {adv:0, disadv:0};
 		if (ev.shiftKey) { output.adv = 1; }
-		if (ev.ctrlKey) { output.disadv = 1; }
+		if (keyboard.isCtrl(ev)) { output.disadv = 1; }
 		return output;
 	}
 	
@@ -387,7 +387,7 @@ export class CustomItemRoll {
 		if (eventToCheck.shiftKey) {
 			this.params.adv = 1;
 		}
-		if (eventToCheck.ctrlKey) {
+		if (keyboard.isCtrl(eventToCheck)) {
 			this.params.disadv = 1;
 		}
 	}


### PR DESCRIPTION
This is MacOS specific issue.

Should have use `keyboard.isCtrl(event)` instead of `event.ctrlKey` to cover `event.metaKey` case, which is used in MacOS systems (CMD button instead of CTRL button). The `keyboard.isCtrl(event)` is function provided by FoundryVTT.