### PR TITLE
Fix for issue 95

### DIFF
--- a/betterrolls5e/module.json
+++ b/betterrolls5e/module.json
@@ -56,5 +56,5 @@
 	"packs": [],
 	"url": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/tree/master/betterrolls5e",
 	"manifest": "https://raw.githubusercontent.com/RedReign/FoundryVTT-BetterRolls5e/master/betterrolls5e/module.json",
-	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/master/betterrolls5e.zip"
+	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/1.1.11(Foundry-0.6.6)/betterrolls5e.zip"
 }

--- a/betterrolls5e/module.json
+++ b/betterrolls5e/module.json
@@ -56,5 +56,5 @@
 	"packs": [],
 	"url": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/tree/master/betterrolls5e",
 	"manifest": "https://raw.githubusercontent.com/RedReign/FoundryVTT-BetterRolls5e/master/betterrolls5e/module.json",
-	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/1.1.11(Foundry-0.6.6)/betterrolls5e.zip"
+	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/master/betterrolls5e.zip"
 }

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -1,6 +1,5 @@
 import { DND5E } from "../../../systems/dnd5e/module/config.js";
 
-import { Utils } from "./utils.js";
 import { BetterRollsHooks } from "./hooks.js";
 import { CustomRoll, CustomItemRoll } from "./custom-roll.js";
 

--- a/betterrolls5e/scripts/chat-damage-buttons.js
+++ b/betterrolls5e/scripts/chat-damage-buttons.js
@@ -1,5 +1,3 @@
-import { DND5E } from "../../../../systems/dnd5e/module/config.js";
-import Actor5e from "../../../../systems/dnd5e/module/actor/entity.js";
 import { i18n, getTargetActors } from "./betterrolls5e.js";
 
 Hooks.on('renderChatMessage', (message, html, data) => {

--- a/betterrolls5e/scripts/hooks.js
+++ b/betterrolls5e/scripts/hooks.js
@@ -1,4 +1,3 @@
-import { DND5E } from "../../../systems/dnd5e/module/config.js";
 import { addBetterRollsContent, addItemSheetButtons, changeRollsToDual, updateSaveButtons, i18n } from "./betterrolls5e.js";
 
 


### PR DESCRIPTION
Fixes https://github.com/RedReign/FoundryVTT-BetterRolls5e/issues/95, by removing the unnecessary imports which were causing the chat damage buttons to not function appropriately when served up behind a reverse proxy using a subdirectory.