### PR TITLE
call custom hook when BetterRolls added to window

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Clicking with/without the Alt key:
 ## Known Issues
 - None which are major.
 
+## Implementation
+Custom sheet creators can register their sheet with Better Rolls 5e using the hooks added to `window` by listening for the `betterRollsAddedToWindow` hook. See the [hooks](betterrolls5e/scripts/hooks.js) file for what is available on the window.
+
+```js
+Hooks.once('betterRollsAddedToWindow', function () {
+  if (window.BetterRolls) {
+    window.BetterRolls.hooks.addActorSheet('OGL5eCharacterSheet');
+  }
+});
+```
+
 ## Acknowledgements
 - Big thanks to Atropos for making a wonderful VTT that's worth making modules for!
 - Thanks are also due to Hooking for the initial Item Sheet Buttons module, without which this project would not exist.

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -772,4 +772,5 @@ export function BetterRolls() {
 
 Hooks.on(`ready`, () => {
 	window.BetterRolls = BetterRolls();
+	Hooks.call('betterRollsAddedToWindow');
 });


### PR DESCRIPTION
Resolves #122 

By adding a custom hook that modules can specifically listen for when trying to implement BetterRolls, we can guarantee that the hooks they need will be on the `window` object.