### PR TITLE
Add initialization of scaleInterval back

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -1306,7 +1306,7 @@ export class CustomItemRoll {
 		return critRoll;
 	}
 	
-	scaleDamage(damageIndex, versatile) {
+	scaleDamage(damageIndex, versatile, scaleInterval = null) {
 		let item = this.item;
 		let itemData = item.data.data;
 		let actorData = item.actor.data.data;


### PR DESCRIPTION
Scaling spells broke for my game tonight. Console logs revealed this error:

```
Uncaught (in promise) ReferenceError: scaleInterval is not defined
    at CustomItemRoll.scaleDamage (custom-roll.js:1336)
    at CustomItemRoll.rollDamage (custom-roll.js:1239)
    at CustomItemRoll.fieldToTemplate (custom-roll.js:616)
    at custom-roll.js:691
```

Git blame reveals v1.1.13 changed the signature of `scaleDamage` to remove this initialization, so I dropped it back in. Hope this helps others.