### PR TITLE
Minor simplifications to the BetterRolls JS

### DIFF
--- a/betterrolls5e/module.json
+++ b/betterrolls5e/module.json
@@ -57,5 +57,5 @@
 	"packs": [],
 	"url": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/tree/master/betterrolls5e",
 	"manifest": "https://raw.githubusercontent.com/RedReign/FoundryVTT-BetterRolls5e/master/betterrolls5e/module.json",
-	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/master/betterrolls5e.zip"
+	"download": "https://github.com/RedReign/FoundryVTT-BetterRolls5e/raw/1.1.14(Foundry-0.7.3)/betterrolls5e.zip"
 }

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -603,9 +603,9 @@ export function BetterRolls() {
 	async function assignMacro(item, slot, mode) {
 		function command() {
 			switch (mode) {
-				case "name": return `BetterRolls.quickRoll("${item.name}");`; break;
-				case "id": return `BetterRolls.quickRollById("${item.actorId}", "${item.data._id}");`; break;
-				case "vanillaRoll": return `BetterRolls.vanillaRoll("${item.actorId}", "${item.data._id}");`; break;
+				case "name": return `BetterRolls.quickRoll("${item.name}");`;
+				case "id": return `BetterRolls.quickRollById("${item.actorId}", "${item.data._id}");`;
+				case "vanillaRoll": return `BetterRolls.vanillaRoll("${item.actorId}", "${item.data._id}");`;
 			}
 		}
 		let macro = game.macros.entities.find(m => (m.name === item.name) && (m.command === command));

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -53,11 +53,11 @@ export function isAttack(item) {
 
 // Returns whether an item requires a saving throw
 export function isSave(item) {
-	let itemData = item.data.data,
-		isTypeSave = (itemData.actionType === "save") ? true : false,
-		hasSaveDC = (itemData.save && itemData.save.ability) ? true : false,
-		output = (isTypeSave || hasSaveDC) ? true : false;
-	return output;
+	const itemData = item.data.data,
+		isTypeSave = itemData.actionType === "save",
+		hasSaveDC = (itemData.save && itemData.save.ability) ? true : false;
+
+	return isTypeSave || hasSaveDC;
 }
 
 // Returns an array with the save DC of the item. If no save is written in, one is calculated.

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -42,13 +42,7 @@ export function getWhisperData() {
 	if ( rollMode === "blindroll" ) blind = true;
 	else if ( rollMode === "selfroll" ) whisper = [game.user._id];
 	
-	let output = {
-		rollMode: rollMode,
-		whisper: whisper,
-		blind: blind
-	}
-	
-	return output;
+	return { rollMode, whisper, blind }
 }
 
 // Returns whether an item makes an attack roll

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -53,9 +53,8 @@ export function getWhisperData() {
 
 // Returns whether an item makes an attack roll
 export function isAttack(item) {
-	let attacks = ["mwak", "rwak", "msak", "rsak"];
-	let output = (attacks.indexOf(item.data.data.actionType) !== -1) ? true : false;
-	return output;
+	const attacks = ["mwak", "rwak", "msak", "rsak"];
+	return attacks.includes(item.data.data.actionType);
 }
 
 // Returns whether an item requires a saving throw

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -91,9 +91,7 @@ export function getSave(item) {
 }
 
 export function isCheck(item) {
-	let itemData = item.data.data;
-	let output = (item.data.type === "tool" || (itemData.proficient && typeof itemData.proficient === "number")) ? true : false;
-	return output;
+	return item.data.type === "tool" || typeof item.data.data.proficient === "number";
 }
 
 let dnd5e = DND5E;

--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -439,13 +439,9 @@ export function updateSaveButtons(html) {
 export function getTargetActors() {
 	const character = game.user.character;
 	const controlled = canvas.tokens.controlled;
-	let actors = [];
 	if ( controlled.length === 0 ) return [character] || null;
 	if ( controlled.length > 0 ) {
-		let actors = [];
-		for (let i = 0; i < controlled.length; i++) {
-			actors.push(controlled[i].actor);
-		}
+		const actors = controlled.map(character => character.actor);
 		return actors;
 	}
 	else throw new Error(`You must designate a specific Token as the roll target`);

--- a/betterrolls5e/scripts/item-tab.js
+++ b/betterrolls5e/scripts/item-tab.js
@@ -5,11 +5,12 @@ let activate = false;
 /**
  * Adds adds the Better Rolls tab to an item's sheet. Should only be called when the sheet is rendered.
  */
-export async function addBetterRollsContent(app, protoHtml, data) {
+export async function addBetterRollsContent(app, protoHtml, _) {
 	const item = app.object;
-	if (item.actor && item.actor.permission < 3) { return; }
 
+	if (item.actor && item.actor.permission < 3) { return; }
 	if (CONFIG.betterRolls5e.validItemTypes.indexOf(item.data.type) == -1) { return; }
+	
 	redUpdateFlags(item);
 
 	let html = protoHtml;
@@ -23,25 +24,24 @@ export async function addBetterRollsContent(app, protoHtml, data) {
 	const betterRollsTabString = `<a class="item" data-group="primary" data-tab="betterRolls5e">${i18n("Better Rolls")}</a>`;
 	tabSelector.append($(betterRollsTabString));
 
-	let settingsContainer = html.find(`.sheet-body`),
-		existingTab = html.find(`.tab.item-betterRolls`);
+	const settingsContainer = html.find(`.sheet-body`),
+		  betterRollsTemplateString = `modules/betterrolls5e/templates/red-item-options.html`,
+		  altSecondaryEnabled = game.settings.get("betterrolls5e", "altSecondaryEnabled");
 
-	let betterRollsTemplateString = `modules/betterrolls5e/templates/red-item-options.html`,
-		altSecondaryEnabled = game.settings.get("betterrolls5e", "altSecondaryEnabled");
+	const isConsumable = item.data.data.consume?.type || item.data.data.uses?.per || item.data.data.recharge?.value || item.data.type == "consumable";
 
-	let canConsume = item.data.data.consume?.type || item.data.data.uses?.per || item.data.data.recharge?.value || item.data.type == "consumable";
-
-	let betterRollsTemplate = await renderTemplate(betterRollsTemplateString, {
+	const betterRollsTemplate = await renderTemplate(betterRollsTemplateString, {
 		DND5E: CONFIG.DND5E,
-		item: item,
-		isConsumable: canConsume,
+		item,
+		isConsumable,
 		isAttack: isAttack(item),
 		isSave: isSave(item),
 		flags: item.data.flags,
 		damageTypes: CONFIG.betterRolls5e.combinedDamageTypes,
-		altSecondaryEnabled: altSecondaryEnabled,
+		altSecondaryEnabled,
 		itemHasTemplate: item.hasAreaTarget
 	});
+
 	settingsContainer.append(betterRollsTemplate);
 
 	// Tab back to better rolls if we need (after certain events it may happen)
@@ -52,27 +52,29 @@ export async function addBetterRollsContent(app, protoHtml, data) {
 
 	// Add damage context input
 	if (game.settings.get("betterrolls5e", "damageContextPlacement") !== "0") {
-		let damageRolls = html.find(`.tab.details .damage-parts .damage-part input`);
+		const damageRolls = html.find(".tab.details .damage-parts .damage-part input");
 		// Placeholder is either "Context" or "Label" depending on system settings
-		let placeholder = game.settings.get("betterrolls5e", "contextReplacesDamage") ? "br5e.settings.label" : "br5e.settings.context";
+		const placeholder = game.settings.get("betterrolls5e", "contextReplacesDamage") ? "br5e.settings.label" : "br5e.settings.context";
 
-		for (let i = 0; i < damageRolls.length; i++) {
-			let contextField = $(`<input type="text" name="flags.betterRolls5e.quickDamage.context.${i}" value="${(item.data.flags.betterRolls5e.quickDamage.context[i] || "")}" placeholder="${i18n(placeholder)}" data-dtype="String" style="margin-left:5px;">`);
-			damageRolls[i].after(contextField[0]);
+		damageRolls.forEach((damageRoll, i) => {
+			const contextField = $(`<input type="text" name="flags.betterRolls5e.quickDamage.context.${i}" value="${(item.data.flags.betterRolls5e.quickDamage.context[i] || "")}" placeholder="${i18n(placeholder)}" data-dtype="String" style="margin-left:5px;">`);
+
+			damageRoll.after(contextField[0]);
+
 			// Add event listener to delete context when damage is deleted
-			$($($(damageRolls[i])[0].parentElement).find(`a.delete-damage`)).click(async event => {
-				let contextFlags = Object.values(item.data.flags.betterRolls5e.quickDamage.context);
+			$($($(damageRoll)[0].parentElement).find(`a.delete-damage`)).click(async _ => {
+				const contextFlags = Object.values(item.data.flags.betterRolls5e.quickDamage.context);
 				contextFlags.splice(i, 1);
 				item.update({
 					[`flags.betterRolls5e.quickDamage.context`]: contextFlags,
 				});
 			});
-		}
+		})
 
 		// Add context field for Other Formula field
 		if (getProperty(item, "data.flags.betterRolls5e.quickOther")) {
-			let otherRoll = html.find(`.tab.details .form-fields input[name="data.formula"]`);
-			let otherContextField = $(`<input type="text" name="flags.betterRolls5e.quickOther.context" value="${(item.data.flags.betterRolls5e.quickOther.context || "")}" placeholder="${i18n(placeholder)}" data-dtype="String" style="margin-left:5px;">`);
+			const otherRoll = html.find(`.tab.details .form-fields input[name="data.formula"]`);
+			const otherContextField = $(`<input type="text" name="flags.betterRolls5e.quickOther.context" value="${(item.data.flags.betterRolls5e.quickOther.context || "")}" placeholder="${i18n(placeholder)}" data-dtype="String" style="margin-left:5px;">`);
 			if (otherRoll[0]) { otherRoll[0].after(otherContextField[0]); }
 		}
 	}

--- a/betterrolls5e/scripts/utils.js
+++ b/betterrolls5e/scripts/utils.js
@@ -1,15 +1,13 @@
 export class Utils {
 	static getCharacterLevel(actor) {
-		// Determine character level and available hit dice based on owned Class items
-		const data = actor.data.data;
-		const [level, hd] = actor.data.items.reduce((arr, item) => {
+		// Determine character level
+		const level = actor.data.items.reduce((runningTotal, item) => {
 			if ( item.type === "class" ) {
 				const classLevels = parseInt(item.data.levels) || 1;
-				arr[0] += classLevels;
-				arr[1] += classLevels - (parseInt(item.data.hitDiceUsed) || 0);
+				runningTotal += classLevels;
 			}
-			return arr;
-		}, [0, 0]);
+			return runningTotal;
+		});
 		return level;
 	}
 }


### PR DESCRIPTION
I had a bit of free time this afternoon, so I've made some simplifications to several of the functions in the BetterRolls code. You can find a summary of pertinent changes below:

- Removes several `for` loops in favour of `forEach` and `map`.
- Simplifies a test in the `isAttack` function.
- Updates several objects to use the ES6 property shorthand.
- Removes a number of unused variables.
- Removes superfluous logic from the `getActorLevel` method, which previously calculated the number of hit dice, but then never returned the result. The new implementation focuses on just the level, which simplifies the function considerably.
- Replaces a number of uses of `let` with `const` as many of the variables defined with `let` are never reassigned.

I haven't tackled some of the larger functions yet, as they're going to be more time consuming, but I'd be happy to submit further changes in the future if this has been helpful.