### PR TITLE
Handling ammo attack bonus and damage rolls

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -1219,7 +1219,7 @@ export class CustomItemRoll {
 		
 		let titleString = "",
 			damageString = [],
-			contextString = flags.quickDamage.context[damageIndex];
+			contextString = flags.quickDamage.context && flags.quickDamage.context[damageIndex];
 		
 		// Show "Healing" prefix only if it's not inherently a heal action
 		if (dnd5e.healingTypes[damageType]) { titleString = ""; }

--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -618,6 +618,12 @@ export class CustomItemRoll {
 						forceCrit: crit
 					}));
 				}
+				if (this._ammo) {
+					this.item = this._ammo;
+					delete this._ammo;
+					await this.fieldToTemplate(['damage', {index: 'all', versatile: false, crit}]);
+					this.item = item;
+				}
 				break;
 			case 'savedc':
 				// {customAbl: null, customDC: null}
@@ -1030,6 +1036,20 @@ export class CustomItemRoll {
 			parts.push(`@bonus`);
 			rollData.bonus = itemData.attackBonus;
 			//console.log("Adding Bonus mod!", itemData);
+		}
+
+		const consume = itemData.consume;
+		if ( consume?.type === "ammo" ) {
+		  const ammo = this.actor.items.get(consume.target);
+		  if(ammo?.data){
+			let ammoBonus = ammo.data.data.attackBonus;
+			if ( ammoBonus ) {
+			parts.push("@ammo");
+			rollData["ammo"] = ammoBonus;
+			title += ` [${ammo.name}]`;
+			this._ammo = ammo;
+			}
+		  }
 		}
 		
 		// Add custom situational bonus


### PR DESCRIPTION
Hey, I have observed the attack bonus and damage rolls from ammo aren't done similarly to normal rolls (no better rolls).

As such, I have tried to see how they were done normally and try to replicate that behavior. At least in the same manner better rolls does for damage.

