### PR TITLE
Targeted readability improvements for chat-damage-buttons.js

### DIFF
--- a/betterrolls5e/scripts/chat-damage-buttons.js
+++ b/betterrolls5e/scripts/chat-damage-buttons.js
@@ -1,28 +1,44 @@
 import { i18n, getTargetActors } from "./betterrolls5e.js";
 
-Hooks.on('renderChatMessage', (message, html, data) => {
+Hooks.on('renderChatMessage', (html) => {
 	if (!game.settings.get("betterrolls5e", "chatDamageButtonsEnabled")) { return; }
     let chatCard = html.find('.red-full');
     if (chatCard.length === 0) { return; }
 	
-	
 	function addButtons(dmgElement) {
         // creating the buttons and container
-        let fullDamageButton = $(`<button data-modifier="1"><i class="fas fa-user-minus" title="${i18n("br5e.chat.damageButtons.fullDamage.hint")}"></i></button>`);
-        let halfDamageButton = $(`<button data-modifier="0.5"><i class="fas fa-user-shield" title="${i18n("br5e.chat.damageButtons.halfDamage.hint")}"></i></button>`);
-        let doubleDamageButton = $(`<button data-modifier="2"><i class="fas fa-user-injured" title="${i18n("br5e.chat.damageButtons.doubleDamage.hint")}"></i></button>`);
-        let fullHealingButton = $(`<button data-modifier="-1"><i class="fas fa-user-plus" title="${i18n("br5e.chat.damageButtons.healing.hint")}"></i></button>`);
+        const fullDamageButton = $(`
+            <button data-modifier="1">
+                <i class="fas fa-user-minus" title="${i18n("br5e.chat.damageButtons.fullDamage.hint")}"></i>
+            </button>
+        `);
 
-        let btnContainer = $('<span class="dmgBtn-container-br"></span>');
+        const halfDamageButton = $(`
+            <button data-modifier="0.5">
+                <i class="fas fa-user-shield" title="${i18n("br5e.chat.damageButtons.halfDamage.hint")}"></i>
+            </button>
+        `);
 
-        btnContainer.append(fullDamageButton);
-        btnContainer.append(halfDamageButton);
-        btnContainer.append(doubleDamageButton);
-        btnContainer.append(fullHealingButton);
+        const doubleDamageButton = $(`
+            <button data-modifier="2">
+                <i class="fas fa-user-injured" title="${i18n("br5e.chat.damageButtons.doubleDamage.hint")}"></i>
+            </button>
+        `);
+
+        const fullHealingButton = $(`
+            <button data-modifier="-1">
+                <i class="fas fa-user-plus" title="${i18n("br5e.chat.damageButtons.healing.hint")}"></i>
+            </button>
+        `);
+
+        const btnContainer = $('<span class="dmgBtn-container-br"></span>');
+
+        btnContainer.append(fullDamageButton, halfDamageButton, doubleDamageButton, fullHealingButton);
 
         // adding the buttons to the the target element
         $(dmgElement).append(btnContainer);
     }
+
     let dmgElements = html.find('.red-base-die').parents('.dice-total'); 
     for (let dmgElement of dmgElements) { addButtons(dmgElement); }
 	

--- a/betterrolls5e/scripts/chat-damage-buttons.js
+++ b/betterrolls5e/scripts/chat-damage-buttons.js
@@ -1,8 +1,9 @@
 import { i18n, getTargetActors } from "./betterrolls5e.js";
 
 Hooks.on('renderChatMessage', (html) => {
+    const chatCard = html.find('.red-full');
+    
 	if (!game.settings.get("betterrolls5e", "chatDamageButtonsEnabled")) { return; }
-    let chatCard = html.find('.red-full');
     if (chatCard.length === 0) { return; }
 	
 	function addButtons(dmgElement) {
@@ -94,13 +95,14 @@ Hooks.on('renderChatMessage', (html) => {
 });
 
 async function applyCritDamage(dmg, critdmg, position) {
-    let dialogResult = await new Promise(async (resolve, reject) => {
-        let options = {};
-        options.left = position.x;
-        options.top = position.y;
-        options.width = 100;
-        
-        let d = new Dialog({
+    const dialogResult = await new Promise(async (resolve, reject) => {
+        const options = {
+            left: position.x,
+            top: position.y,
+            width: 100 
+        };
+
+        const data = {
             title: i18n("br5e.chat.damageButtons.critPrompt.title"),
             content: "",
             buttons: {
@@ -115,9 +117,11 @@ async function applyCritDamage(dmg, critdmg, position) {
                     callback: () => { resolve(dmg); }
                 }
             },
-            default: "two",
-        }, options);
-        d.render(true);
+            default: "two"
+        }
+
+        new Dialog(data, options).render(true);
     });
+
     return dialogResult;
 }

--- a/betterrolls5e/scripts/chat-damage-buttons.js
+++ b/betterrolls5e/scripts/chat-damage-buttons.js
@@ -40,10 +40,9 @@ Hooks.on('renderChatMessage', (_, html, _) => {
     }
 
     const dmgElements = html.find('.red-base-die').parents('.dice-total').toArray(); 
-    dmgElements.forEach(element => { addButtons(element) });
-	
     const customElements = html.find('[data-type=custom] .red-base-die').toArray();
-    customElements.forEach(element => { addButtons(element) });
+    
+    [...dmgElements, ...customElements].forEach(element => { addButtons(element) });
 
     // adding click events to the buttons, this gets redone since they can break through rerendering of the card
 	html.find('.dmgBtn-container-br button').click(async ev => {

--- a/betterrolls5e/scripts/chat-damage-buttons.js
+++ b/betterrolls5e/scripts/chat-damage-buttons.js
@@ -1,8 +1,8 @@
 import { i18n, getTargetActors } from "./betterrolls5e.js";
 
-Hooks.on('renderChatMessage', (html) => {
+Hooks.on('renderChatMessage', (_, html, _) => {
     const chatCard = html.find('.red-full');
-    
+
 	if (!game.settings.get("betterrolls5e", "chatDamageButtonsEnabled")) { return; }
     if (chatCard.length === 0) { return; }
 	


### PR DESCRIPTION
I've made a much smaller set of changes this time around, focused entirely on `chat-damage-buttons.js`.

- Removes several unnecessary and / or unused variables.
- Replaces several uses of `let` with `const`.
- Corrects some minor indentation issues.
- Splits up the templates strings for the HTML over several lines, making them much easier to read.
- Updates the `options` object for the `Dialog` so that it is created with its final properties, rather than updating the empty object immediately after creating it.
- Extracts the arguments for the `Dialog` to constants to improve readability. This also allows us to call `render` on the same line without needing to assign the `Dialog` to a variable.

