### PR TITLE
Fix cantrip scaling - add missing initial value to reduce call

### DIFF
--- a/betterrolls5e/scripts/utils.js
+++ b/betterrolls5e/scripts/utils.js
@@ -7,7 +7,7 @@ export class Utils {
 				runningTotal += classLevels;
 			}
 			return runningTotal;
-		});
+		}, 0);
 		return level;
 	}
 


### PR DESCRIPTION
Cantrip scaling is broken because `Utils.getCharacterLevel` uses a reduce call without passing an initial value, so the initial value is an object and the subsequent math fails.  The end result is that the cantrip scaling logic always adds 1 extra damage roll no matter the character level.

This PR fixes that and resolves #151.   

