### PR TITLE
FIX: Double damage dices when disaventage roll contain a critical success

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -958,7 +958,7 @@ export class CustomItemRoll {
 			if ((high > 0) && (low == 0)) $($html.find(selector)[i]).addClass("success");
 			else if ((high == 0) && (low > 0)) $($html.find(selector)[i]).addClass("failure");
 			else if ((high > 0) && (low > 0)) $($html.find(selector)[i]).addClass("mixed");
-			if ((high > 0) || (args.isCrit == true)) isCrit = true;
+			if (!rolls[i].ignored && ((high > 0) || (args.isCrit == true))) isCrit = true;
 		}
 		return {
 			html: $html[0].outerHTML,


### PR DESCRIPTION
Fix for issue #148
Simply added checking of 'ignored' when determining if roll was critical.