### PR TITLE
Fix 2 issues in custom-roll that break tool rolls

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -1502,7 +1502,7 @@ export class CustomItemRoll {
 		
 		// Halfling Luck check
 		let d20String = "1d20";
-		if (Utils.isHalfling(itm,actor)) {
+		if (Utils.isHalfling(itm.actor)) {
 			d20String = "1d20r<2";
 		}
 		
@@ -1600,7 +1600,7 @@ export class CustomItemRoll {
 		let item = this.item,
 			itemData = item.data.data;
 		
-		const hasUses = !!(itemData.uses.value || itemData.uses.max || itemData.uses.per); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
+		const hasUses = !!(itemData.uses?.value || itemData.uses?.max || itemData.uses?.per); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
 		const hasResource = !!(itemData.consume?.target); // Actual check to see if a resource is entered on the item, even if params.useCharge.resource == true
 
 		const request = this.params.useCharge; // Has bools for quantity, use, resource, and charge


### PR DESCRIPTION
Two separate problems in this script cause tools in 5e to not be able to roll correctly. One is an incorrect comma, the other is the lack of a nullcheck when referencing item data uses. Fixed both errors and tested them locally before proposing these changes.