### PR TITLE
use setTimeout to ensure we go after other sheet render hooks

### DIFF
--- a/betterrolls5e/scripts/hooks.js
+++ b/betterrolls5e/scripts/hooks.js
@@ -32,8 +32,11 @@ export class BetterRollsHooks {
 		params = {}) {
 		let sheetString = "render" + sheetName;
 		Hooks.on(sheetString, (app, html, data) => {
-			game.settings.get("betterrolls5e", "rollButtonsEnabled") ? addItemSheetButtons(app.object, html, data, triggeringElement, buttonContainer) : null;
-			game.settings.get("betterrolls5e", "diceEnabled") ? changeRollsToDual(app.object, html, data, params) : null;
+			// this timeout allows other modules to modify the sheet before we do
+			setTimeout(() => {
+				game.settings.get("betterrolls5e", "rollButtonsEnabled") ? addItemSheetButtons(app.object, html, data, triggeringElement, buttonContainer) : null;
+				game.settings.get("betterrolls5e", "diceEnabled") ? changeRollsToDual(app.object, html, data, params) : null;
+			}, 0);
 		});
 	}
 	


### PR DESCRIPTION
Discussed on discord, this allows other sheet modifying modules to inject HTML into the sheet before Better Rolls modifies the listeners on that sheet html.

Useful for the sort of modules like [Character Actions List 5e](https://github.com/ElfFriend-DnD/foundryvtt-dnd5eCharacterActions)