### PR TITLE
Max Base Damage and Roll Critical Damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Upgrading rolls after they're made, as well as a damage button:
 ## Planned Features
 - Additional macro support
 - Extended prompts to configure messages on a roll-by-roll basis
-- Additional hooks suppot and chat message flags for module cross-compatibility
+- Additional hooks support and chat message flags for module cross-compatibility
 
 ## Known Issues
 - In versions prior to 1.1.12, there exists a bug where, if used alongside tidy5e, Actor data may increase exponentially. This has since been addressed in 1.1.12. **If you are using Foundry Virtual Tabletop 0.7.0 or higher, please update to Better Rolls 1.1.12.**

--- a/betterrolls5e/lang/en.json
+++ b/betterrolls5e/lang/en.json
@@ -61,6 +61,7 @@
 	"br5e.critBehavior.choices.1": "Roll Critical Damage Dice",
 	"br5e.critBehavior.choices.2": "Roll Base Damage, Max Critical",
 	"br5e.critBehavior.choices.3": "Max Base & Critical Damage",
+	"br5e.critBehavior.choices.4": "Max Base Damage, Roll Critical Damage",
 	
 	"br5e.critString.name": "Critical Indicator",
 	"br5e.critString.hint": "Determines how criticals are labeled. Appears as text to the right of the critical damage roll. Only works on Better Rolls.",

--- a/betterrolls5e/scripts/settings.js
+++ b/betterrolls5e/scripts/settings.js
@@ -176,6 +176,7 @@ class Settings {
 				"1": i18n("br5e.critBehavior.choices.1"), // Roll Critical Damage Dice
 				"2": i18n("br5e.critBehavior.choices.2"), // Roll Base Damage, Max Critical
 				"3": i18n("br5e.critBehavior.choices.3"), // Max Base & Critical Damage
+				"4": i18n("br5e.critBehavior.choices.4"), // Max Base Damage, Roll Critical Damage
 			}
 		});
 		

--- a/betterrolls5e/scripts/utils.js
+++ b/betterrolls5e/scripts/utils.js
@@ -771,6 +771,15 @@ export class ItemUtils {
 			critRoll = new Roll(newFormula).evaluate({maximize:true});
 		}
 
+		// If critBehavior = 4, maximize base dice and roll crit dice
+		// Need to get the difference because we're not able to change the base roll from here so we add it to the critical roll
+		else if (critBehavior === "4") {
+			let maxRoll = new Roll(baseFormula).evaluate({maximize:true});
+			let maxDifference = maxRoll.total - baseTotal;
+			let newFormula = critRoll.formula + "+" + maxDifference.toString();
+			critRoll = new Roll(newFormula).evaluate();
+		}
+
 		return critRoll;
 	}
 


### PR DESCRIPTION
Adding option for critical damage rolls to maximize base damage and roll critical damage. Also fixing a typo on the README file
Fixes #208 