### PR TITLE
Future-proof Illandril's Hotbar Uses macro compatibility

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -466,6 +466,7 @@ export function BetterRolls() {
 		function command() {
 			const vanilla = mode === 'vanillaRoll' ? "true" : "false";
 			return `
+// HotbarUses5e: ActorID="${item.actorId}" ItemID="${item.data._id}"
 const actorId = "${item.actorId}";
 const itemId = "${item.data._id}";
 const actorToRoll = canvas.tokens.placeables.find(t => t.actor?.id === actorId)?.actor ?? game.actors.get(actorId);


### PR DESCRIPTION
By adding this comment to the Macros (and persisting it with any future macro format changes), it ensures that my module (Illandril's Hotbar Uses) will be able to know what item the macro is a roll for and show appropriate Use counters, even if the specifics of the macro format changes again in the future. See https://github.com/illandril/FoundryVTT-hotbar-uses/issues/28.

I'm releasing a new version of Illandril's Hotbar Uses to match against the current macro format, so this comment isn't needed right now... but the matching I've added is very dependent on the specific formatting currently used by BetterRolls. If even the slightest change is made to the macros generated by BetterRolls, that matching could break.