### PR TITLE
Fix Itemmacro call from hotbar

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -471,6 +471,11 @@ const actorId = "${item.actorId}";
 const itemId = "${item.data._id}";
 const actorToRoll = canvas.tokens.placeables.find(t => t.actor?.id === actorId)?.actor ?? game.actors.get(actorId);
 const itemToRoll = actorToRoll?.items.get(itemId);
+
+if (game.modules.get('itemacro')?.active && itemToRoll.hasMacro()) {
+	return itemToRoll.executeMacro();
+}
+
 if (!itemToRoll) {
 	return ui.notifications.warn(game.i18n.format("DND5E.ActionWarningNoItem", { item: itemId, name: actorToRoll?.name ?? "[Not Found]" }));
 }


### PR DESCRIPTION
Hi,

Trying to fix itemmacro not working from the hotbar.
Tried quite a few things, but always get into a loop.

The only way I found was to update the macro template. Even tho it's not ideal, I didn't find any other solution.
Because the default BR macro calls directly the overwritten `roll` function. And there is no way around that, expect serious refactoring.

Maybe you have a better idea?

This PR has no impact on existing BR installation or if ItemMacro is not installed/activated.