### PR TITLE
Pass along the speaker to DSN for NPC handling

### DIFF
--- a/betterrolls5e/scripts/utils/dice-collection.js
+++ b/betterrolls5e/scripts/utils/dice-collection.js
@@ -52,7 +52,7 @@ export class DiceCollection {
 		const hasDice = pool.dice.length > 0;
 		if (game.dice3d && hasDice) {
 			const wd = whisperData ?? Utils.getWhisperData();
-			await game.dice3d.showForRoll(pool, game.user, true, wd.whisper, wd.blind || false);
+			await game.dice3d.showForRoll(pool, game.user, true, wd.whisper, wd.blind || false, null, wd.speaker);
 		}
 
 		const sound = Utils.getDiceSound(hasMaestroSound);


### PR DESCRIPTION
BetterRolls5e isn't passing along speaker information to Dice So Nice for GM Rolls. DNS needs to know the speaker in order to determine whether or not to hide the roll _when the DM rolls it_.

**Steps to Reproduce (before adding my change)**
1. Log into foundry as a DM in one window, and a player in an incognito window
2. In Module Settings for Dice So Nice, make sure "Disable 3D dice on NPC rolls" is checked.
3. As the DM, have an NPC roll the dice.

**Result**: the player will see the animated dice roll.

When you add my change in, dice will no longer roll for an NPC because DSN's checks kick in