### PR TITLE
feat-active-effect-self

### DIFF
--- a/betterrolls5e/scripts/chat-message.js
+++ b/betterrolls5e/scripts/chat-message.js
@@ -358,7 +358,14 @@ export class BetterRollsChatCard {
 			if (data.ammo) {
 				item = item.parent.items.get(item.data.data.consume.target)
 			}
-			const targets = game.user.targets.size ? game.user.targets : Utils.getTargetTokens();
+
+			let targets
+			if (item.data.data?.target?.type === 'self' && canvas.tokens?.controlled?.length) {
+				targets = Utils.getTargetTokens();
+			} else {
+				targets = game.user.targets.size ? game.user.targets : Utils.getTargetTokens();
+			}
+
 			window.DAE.doEffects(item, true, targets, {
 				whisper: false,
 				spellLevel: roll.params.slotLevel,


### PR DESCRIPTION
Hello,

Really simple PR.
If the item has a "self" target when clicking on the "Apply Active Effects", it applies the active effects on the selected/player token rather than the targeted token.

The GM can still apply a "self" effect on other tokens by selecting or targeting tokens and click on the button.