### PR TITLE
Fix hasUses when using a string rather than a number

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -1212,7 +1212,7 @@ export class CustomItemRoll {
 		}
 
 		const itemData = item.data.data;
-		const hasUses = !!(Number(itemData.uses?.value) || Number(itemData.uses?.max)); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
+		const hasUses = !!(Number(itemData.uses?.value) || itemData.uses?.max); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
 		const hasResource = !!(itemData.consume?.target); // Actual check to see if a resource is entered on the item, even if params.useCharge.resource == true
 
 		const request = this.params.useCharge; // Has bools for quantity, use, resource, and charge


### PR DESCRIPTION
Hello,

This is a fix for uses consumption.

With the latest 5e version, the max field can accept **strings** and numbers.
A lot of items are now referencing `@attributes` or `@classes` to get the maximum usage.
![image](https://user-images.githubusercontent.com/1687854/133933415-d4e0479b-835c-4844-9b79-57426ba16411.png)

Previously the value was cast to a Number which resulted in `NaN` making BetterRolls believe that the item didn't have charges configured.

This PR just remove the assumption that max uses is always a Number.