### PR TITLE
Fix usage

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -1212,7 +1212,7 @@ export class CustomItemRoll {
 		}
 
 		const itemData = item.data.data;
-		const hasUses = !!(Number(itemData.uses?.value) || itemData.uses?.max); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
+		const hasUses = !!(Number(itemData.uses?.value) || itemData.uses?.per); // Actual check to see if uses exist on the item, even if params.useCharge.use == true
 		const hasResource = !!(itemData.consume?.target); // Actual check to see if a resource is entered on the item, even if params.useCharge.resource == true
 
 		const request = this.params.useCharge; // Has bools for quantity, use, resource, and charge


### PR DESCRIPTION
Hey,

Quick fix for the item uses consumption.
By default, a new item is created with the following configuration:
![image](https://user-images.githubusercontent.com/1687854/134329894-10af4dc1-ca76-43c1-8546-067855750422.png)

The previous fix wasn't working in this case, it warned that the item has no uses. Which is kinda true, but handled differently in the core 5e system. Since it's the default configuration for a newly created item, we shouldn't stop the user here.
Decided to use the same method as the default 5e system. Checking "per" instead of "max"