### PR TITLE
Fixes for "Info" button

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -351,7 +351,7 @@ async function addButtonsToItemLi(li, actor, buttonContainer) {
 			case 'otherFormulaRoll':
 				fields.push(["other"]); break;
 			case 'infoRoll':
-				fields.push(["desc"]); params.properties = true; break;
+				fields.push(["header"], ["desc"]); params.consume = false; params.properties = true; break;
 			case 'vanillaRoll':
 				item.roll({ vanilla: true });
 		}


### PR DESCRIPTION
1. Display the card header.  If "Collapse Item Cards In Chat" setting is enabled, there was no way to expand the hidden text if the header was not displayed.
2. Don't consume any ammo or spell slots.