### PR TITLE
added two new ways for calculating critical damage

### DIFF
--- a/betterrolls5e/lang/en.json
+++ b/betterrolls5e/lang/en.json
@@ -62,6 +62,8 @@
 	"br5e.critBehavior.choices.2": "Roll Base Damage, Max Critical",
 	"br5e.critBehavior.choices.3": "Max Base & Max Critical Damage",
 	"br5e.critBehavior.choices.4": "Max Base Damage, Roll Critical Damage",
+	"br5e.critBehavior.choices.5": "Double Base Damage Dice Value",
+	"br5e.critBehavior.choices.6": "Double Base Damage Dice Value and Modifiers",
 
 	"br5e.critString.name": "Critical Indicator",
 	"br5e.critString.hint": "Determines how criticals are labeled. Appears as text to the right of the critical damage roll. Only works on Better Rolls.",

--- a/betterrolls5e/lang/pt-BR.json
+++ b/betterrolls5e/lang/pt-BR.json
@@ -60,6 +60,8 @@
 	"br5e.critBehavior.choices.1": "Rolar dados de Dano Crítico",
 	"br5e.critBehavior.choices.2": "Rolar Dano Base, Maximizar Crítico",
 	"br5e.critBehavior.choices.3": "Maximizar Base e Dano Crítico",
+	"br5e.critBehavior.choices.5": "Dobrar o valor do Dado de Dano Base",
+	"br5e.critBehavior.choices.6": "Dobrar o valor do Dado de Dano Base e dos Modificadores",
 
 	"br5e.critString.name": "Indicador Crítico",
 	"br5e.critString.hint": "Determina como os críticos são rotulados. Aparece como texto à direita da rolagem de dano crítico. Funciona apenas com Rolagens Melhores.",

--- a/betterrolls5e/scripts/fields.js
+++ b/betterrolls5e/scripts/fields.js
@@ -269,14 +269,27 @@ export class RollFields {
 		// Assemble roll data and defer to the general damage construction
 		try {
 			const rollFormula = [formula, ...parts].join("+");
-			const baseRoll = new Roll(rollFormula, rollData).roll();
+			var baseRoll = new Roll(rollFormula, rollData).roll();
 			const total = baseRoll.total;
 
 			// Roll crit damage if relevant
 			let critRoll = null;
 			if (damageIndex !== "other") {
-				if (isCrit && critBehavior !== "0") {
-					critRoll = ItemUtils.getCritRoll(baseRoll.formula, total, { settings, extraCritDice });
+				if (isCrit){
+					//if critBehavior = 5, double the base damage dice value
+					//modifies the formula of the base roll to be base dice x 2 and rerolls it
+					if (critBehavior === "5") {
+						var formulaSplit = formula.split("+");
+						var newFormula = formulaSplit[0] + " * 2 +" + formulaSplit.slice(1).join("+");
+						baseRoll = new Roll(newFormula, rollData).roll();
+					}
+					if (critBehavior === "6") {
+						critRoll = baseRoll;
+					}
+					//If critbehavior != 5, 6 or 0, roll crit damage dice based on choosen option
+					else if (critBehavior !== "0") {
+						critRoll = ItemUtils.getCritRoll(baseRoll.formula, total, { settings, extraCritDice });
+					}
 				}
 			}
 

--- a/betterrolls5e/scripts/settings.js
+++ b/betterrolls5e/scripts/settings.js
@@ -177,6 +177,8 @@ class Settings {
 				"2": i18n("br5e.critBehavior.choices.2"), // Roll Base Damage, Max Critical
 				"3": i18n("br5e.critBehavior.choices.3"), // Max Base & Critical Damage
 				"4": i18n("br5e.critBehavior.choices.4"), // Max Base Damage, Roll Critical Damage
+				"5": i18n("br5e.critBehavior.choices.5"), // Double Base Damage Dice Value
+				"6": i18n("br5e.critBehavior.choices.6"), // Double Base Damage Dice Value and Modifiers
 			}
 		});
 


### PR DESCRIPTION
Hey guys, I decided to implement my suggestion on [this issue](https://github.com/RedReign/FoundryVTT-BetterRolls5e/issues/340). I've added two new ways of rolling critical damage:

- Doubling the dice value and then adding the modifiers
- Doubling the dice value and the modifiers

Those are two house rules that I know that are pretty common in D&D (the first one is used by Matthew Mercer in Critical Role, which is pretty popular) so I guess they'll be good additions to the module.

I've also translated these new choices to pt-BR since I'm Brazilian, so I hope that's not an issue. Can't help about the other languages though. 

Feel free to suggest any edits or modifications!