### PR TITLE
Added infoOnly flag

### DIFF
--- a/betterrolls5e/scripts/betterrolls5e.js
+++ b/betterrolls5e/scripts/betterrolls5e.js
@@ -340,7 +340,7 @@ async function addButtonsToItemLi(li, actor, buttonContainer) {
 			case 'otherFormulaRoll':
 				fields.push(["other"]); break;
 			case 'infoRoll':
-				fields.push(["header"], ["desc"]); params.consume = false; params.properties = true; break;
+				fields.push(["header"], ["desc"]); params.consume = false; params.properties = true; params.infoOnly = true; break;
 			case 'vanillaRoll':
 				item.roll({ vanilla: true });
 		}

--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -130,7 +130,7 @@ let defaultParams = {
 	advantage: 0,
 	disadvantage: 0,
 	consume: true,
-	infoOnly: false
+	infoOnly: false,
 };
 
 /*

--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -129,7 +129,8 @@ let defaultParams = {
 	event: null,
 	advantage: 0,
 	disadvantage: 0,
-	consume: true
+	consume: true,
+	infoOnly: false
 };
 
 /*


### PR DESCRIPTION
Added an `infoOnly` flag to `params`.  This get propagated to `message.flags.betterrolls5e.params.infoOnly`.

The reason behind this is to help fix an issue in [CUB](https://github.com/death-save/combat-utility-belt).  Currently CUB will think you are concentrating on a spell if you click the Info button.  By adding this flag, CUB will be able to see that a message is just an info dump, and not apply concentration checks to it.

I will be submitting a PR to CUB to fix the issue on that side too.