### PR TITLE
Simple fix for use of Item5e.createOwned

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -266,8 +266,9 @@ export class CustomItemRoll {
 		}
 
 		const actor = await this.getActor();
-		const Item5e = game.dnd5e.entities.Item5e;
-		const item = storedData && actor ? Item5e.createOwned(storedData, actor) : actor?.items.get(this.itemId);
+		const item = storedData && actor
+			? await actor.createEmbeddedDocuments("Item", [storedData])[0]
+			: actor?.items.get(this.itemId);
 		if (item) {
 			console.info(`BetterRolls | Card loaded existing item data ${item.name}`);
 		}


### PR DESCRIPTION
Remove use of Item5e.createOwned as this has been dropped from the product.
This was causing issues when BetterRolls5e was interacting with spells that were fired from [Magic Items](https://foundryvtt.com/packages/magicitems)