### PR TITLE
Bugfix for ammo bug

### DIFF
--- a/betterrolls5e/scripts/custom-roll.js
+++ b/betterrolls5e/scripts/custom-roll.js
@@ -702,6 +702,8 @@ export class CustomItemRoll {
 		}
 
 		// Consume ammo (now that fields have been processed)
+		// ammoUpdate may be an array containing the actual object we're interested in at entry 0
+		if(ammo && Array.isArray(ammoUpdate)){ ammoUpdate = ammoUpdate[0]; }
 		if (ammo && !isObjectEmpty(ammoUpdate)) {
 			await ammo.update(ammoUpdate);
 		}


### PR DESCRIPTION
It seems the Dnd5e system (version 1.6.0) broke the BetterRolls5e v1.7.2 ability for weapons to draw ammo when it has an ammo source set. Instead it throws an error.
The issue is, BetterRolls5e assumes an object called 'ammoUpdate' to contain the ammo source data it needs.
As of Dnd5e v1.6.0, it appears 'ammoUpdate' now is an array containing the actual data BetterRolls5e needs.